### PR TITLE
Interface preflabels

### DIFF
--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -1425,7 +1425,7 @@ An expression of a work may include expressions of other works within it. For in
 If an instance of F2 Expression is of a specific form, such as text, image, etc., it may be simultaneously instantiated in the specific classes representing these forms in CIDOC CRM. Thereby one can make use of the more specific properties of these classes, such as language (which is applicable to instances of E33 Linguistic Object only).</rdfs:comment>
         <rdfs:label xml:lang="en">F2 Expression</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F2</skos:notation>
-        <skos:prefLabel xml:lang="en">Propositional Object</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">Resource</skos:prefLabel>
     </owl:Class>
     
 
@@ -1438,7 +1438,7 @@ If an instance of F2 Expression is of a specific form, such as text, image, etc.
 			were produced by an industrial process involving an F3 Manifestation Product Type. </rdfs:comment>
         <rdfs:label xml:lang="en">F5 Item</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F5</skos:notation>
-        <skos:prefLabel xml:lang="en">Information Carrier</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">Item</skos:prefLabel>
     </owl:Class>
     
 
@@ -1451,9 +1451,99 @@ If an instance of F2 Expression is of a specific form, such as text, image, etc.
             CRM classes. E55 Type is the CRM’s interface to domain specific ontologies and thesauri. These can be represented in the CRM as subclasses
             of E55 Type, forming hierarchies of terms, i.e. instances of E55 Type linked via P127 has broader term (has narrower term). Such
             hierarchies may be extended with additional properties. </rdfs:comment>
-        <rdfs:label xml:lang="en">Type</rdfs:label>
+        <rdfs:label xml:lang="en">E55 Type</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E55</skos:notation>
         <skos:prefLabel xml:lang="en">Type</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://www.cidoc-crm.org/cidoc-crm/E21 -->
+
+    <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E21">
+        <rdfs:label xml:lang="en">E21 Person</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E21</skos:notation>
+        <skos:prefLabel xml:lang="en">Reader</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://www.cidoc-crm.org/cidoc-crm/E7 -->
+
+    <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E7">
+        <rdfs:label xml:lang="en">E7 Activity</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E7</skos:notation>
+        <skos:prefLabel xml:lang="en">Act of Reading</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://erlangen-crm.org/current/E67_Birth -->
+
+    <owl:Class rdf:about="http://erlangen-crm.org/current/E67_Birth">
+        <rdfs:label xml:lang="en">E67 Birth</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E67</skos:notation>
+        <skos:prefLabel xml:lang="en">Date of Birth</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://erlangen-crm.org/current/E69_Death -->
+
+    <owl:Class rdf:about="http://erlangen-crm.org/current/E69_Death">
+        <rdfs:label xml:lang="en">E69 Death</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E69</skos:notation>
+        <skos:prefLabel xml:lang="en">Date of Death</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://www.cidoc-crm.org/cidoc-crm/E53 -->
+
+    <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E53">
+        <rdfs:label xml:lang="en">E53 Place</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E53</skos:notation>
+        <skos:prefLabel xml:lang="en">Place</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://www.cidoc-crm.org/cidoc-crm/E50 -->
+
+    <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E50">
+        <rdfs:label xml:lang="en">E50 Date</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E50</skos:notation>
+        <skos:prefLabel xml:lang="en">Date</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://erlangen-crm.org/current/E35_Title-->
+
+    <owl:Class rdf:about="http://erlangen-crm.org/current/E35_Title">
+        <rdfs:label xml:lang="en">E35 Title</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E35</skos:notation>
+        <skos:prefLabel xml:lang="en">Title</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://www.cidoc-crm.org/cidoc-crm/E39 -->
+
+    <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E39">
+        <rdfs:label xml:lang="en">E39 Actor</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E39</skos:notation>
+        <skos:prefLabel xml:lang="en">Author</skos:prefLabel>
+    </owl:Class>
+
+
+
+    <!-- http://www.cidoc-crm.org/cidoc-crm/E56 -->
+
+    <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E56">
+        <rdfs:label xml:lang="en">E56 Language</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E56</skos:notation>
+        <skos:prefLabel xml:lang="en">Language</skos:prefLabel>
     </owl:Class>
 </rdf:RDF>
 

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -955,6 +955,7 @@
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms from thesauri and controlled vocabularies used to characterize and classify the circumstances of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO1 Circumstances</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO1</skos:notation>
+        <skos:prefLabel xml:lang="en">Circumstances</skos:prefLabel>
     </owl:Class>
     
 
@@ -966,6 +967,7 @@
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms from thesauri and controlled vocabularies used to characterize and classify the nationality of E21 Person at the moment of E7 Activity or at a given time. It is considered the legal identification of belonging to one (or more) political, ethnic or linguistic groups</rdfs:comment>
         <rdfs:label xml:lang="en">REO10 Nationality</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO10</skos:notation>
+        <skos:prefLabel xml:lang="en">Nationality</skos:prefLabel>
     </owl:Class>
     
 
@@ -977,6 +979,7 @@
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms from thesauri and controlled vocabularies used to characterize and classify the occupation of E21 Person at the moment of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO11 Occupation</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO11</skos:notation>
+        <skos:prefLabel xml:lang="en">Occupation</skos:prefLabel>
     </owl:Class>
     
 
@@ -990,6 +993,7 @@
 The outcome is considered direct effect or consequence resulting from E7 Activity which it follows. Outcome is considered immaterial as it mainly affects the state of mind and the condition of the E39 Actor or E21 Person. Outcome is not only consisting in a change of the state of mind but also in a change of the situation of the E39 Actor or E21 Person. There may be one or many outcomes resulting from E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO12_Outcomes (external processes)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO12</skos:notation>
+        <skos:prefLabel xml:lang="en">Outcomes (external processes)</skos:prefLabel>
     </owl:Class>
     
 
@@ -1002,6 +1006,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify the physical position or posture of E21 Person during E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO13 Position</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO13</skos:notation>
+        <skos:prefLabel xml:lang="en">Position</skos:prefLabel>
     </owl:Class>
     
 
@@ -1013,6 +1018,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify informations about how E21 Person obtained F5 Item.</rdfs:comment>
         <rdfs:label xml:lang="en">REO14 Provenance</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO14</skos:notation>
+        <skos:prefLabel xml:lang="en">Provenance</skos:prefLabel>
     </owl:Class>
     
 
@@ -1024,6 +1030,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms from thesauri and controlled vocabularies used to characterize and classify the religion of E21 Person at the moment of E7 Activity or at a given time.</rdfs:comment>
         <rdfs:label xml:lang="en">REO15 Religion (temporal entity)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO15</skos:notation>
+        <skos:prefLabel xml:lang="en">Religion</skos:prefLabel>
     </owl:Class>
     
 
@@ -1036,6 +1043,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify the publication status of the F2 Expression.</rdfs:comment>
         <rdfs:label xml:lang="en">REO16 Status</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO16</skos:notation>
+        <skos:prefLabel xml:lang="en">Status</skos:prefLabel>
     </owl:Class>
     
 
@@ -1047,6 +1055,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the terms used to characterize a regular, habitual or inferquent practice of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO17 Habit</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO17</skos:notation>
+        <skos:prefLabel xml:lang="en">Habit</skos:prefLabel>
     </owl:Class>
     
 
@@ -1058,6 +1067,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The stated aim, objective, motivation or intention behind the reading.</rdfs:comment>
         <rdfs:label xml:lang="en">REO18 Aim</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO18</skos:notation>
+        <skos:prefLabel xml:lang="en">Aim</skos:prefLabel>
     </owl:Class>
     
 
@@ -1069,6 +1079,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">REO19 Skill</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO19</skos:notation>
+        <skos:prefLabel xml:lang="en">Reading Ability</skos:prefLabel>
     </owl:Class>
     
 
@@ -1081,6 +1092,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
 Premises are considered as the set of personal immaterial dispositions (motivation, inspiration, constraint ...) that lead to the realization of an E7 activity they precede. There may be one or more premises.</rdfs:comment>
         <rdfs:label xml:lang="en">REO2 Disposition</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO2</skos:notation>
+        <skos:prefLabel xml:lang="en">Disposition</skos:prefLabel>
     </owl:Class>
     
 
@@ -1092,6 +1104,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">REO20 Understanding</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO20</skos:notation>
+        <skos:prefLabel xml:lang="en">Understanding</skos:prefLabel>
     </owl:Class>
     
 
@@ -1103,6 +1116,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">REO21 Emotions</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO21</skos:notation>
+        <skos:prefLabel xml:lang="en">Emotions</skos:prefLabel>
     </owl:Class>
     
 
@@ -1114,6 +1128,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Evaluative report of F2 Expression</rdfs:comment>
         <rdfs:label xml:lang="en">REO22 Evaluation</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO22</skos:notation>
+        <skos:prefLabel xml:lang="en">Evaluation</skos:prefLabel>
     </owl:Class>
     
 
@@ -1125,6 +1140,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize the emotional, intellectual, or psychological effect that the E7 Activity has on the E21 Person at the time of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO23 Effects (internal processes)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO23</skos:notation>
+        <skos:prefLabel xml:lang="en">Effects (internal processes)</skos:prefLabel>
     </owl:Class>
     
 
@@ -1136,6 +1152,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Non-evaluative report of a F2 Expression</rdfs:comment>
         <rdfs:label xml:lang="en">REO26 Summary</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO26</skos:notation>
+        <skos:prefLabel xml:lang="en">Summary</skos:prefLabel>
     </owl:Class>
     
 
@@ -1147,6 +1164,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A sensory perception and representation enhanced by F2 Expression </rdfs:comment>
         <rdfs:label xml:lang="en">REO27 Mental imagery</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO27</skos:notation>
+        <skos:prefLabel xml:lang="en">Mental Imagery</skos:prefLabel>
     </owl:Class>
     
 
@@ -1158,6 +1176,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the act of remembering, or the thing remembered : memory, remembrance, recollection, reminiscence of something previously done</rdfs:comment>
         <rdfs:label xml:lang="en">REO28 Memories (textual)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO28</skos:notation>
+        <skos:prefLabel xml:lang="en">Memories (of reading)</skos:prefLabel>
     </owl:Class>
     
 
@@ -1169,6 +1188,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the act of remembering, or the thing remembered: memory, remembrance, recollection, reminiscence of an event, idea, notion </rdfs:comment>
         <rdfs:label xml:lang="en">REO29 Memories (non textual)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO29</skos:notation>
+        <skos:prefLabel xml:lang="en">Memories (other)</skos:prefLabel>
     </owl:Class>
     
 
@@ -1180,6 +1200,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify the environmental conditions under which E7 Activity took place.</rdfs:comment>
         <rdfs:label xml:lang="en">REO3 Environment</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO3</skos:notation>
+        <skos:prefLabel xml:lang="en">Environment</skos:prefLabel>
     </owl:Class>
     
 
@@ -1191,6 +1212,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The expectation of what F2 Expression might be like, before the actual E7 Activity has taken place. This includes anticipation.</rdfs:comment>
         <rdfs:label xml:lang="en">REO30 Expectations</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO30</skos:notation>
+        <skos:prefLabel xml:lang="en">Expectations</skos:prefLabel>
     </owl:Class>
     
 
@@ -1202,6 +1224,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Activity of a result of E7 activity</rdfs:comment>
         <rdfs:label xml:lang="en">REO31 Action</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO31</skos:notation>
+        <skos:prefLabel xml:lang="en">Action</skos:prefLabel>
     </owl:Class>
     
 
@@ -1213,6 +1236,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Where E7 Activity has caused a change in thinking </rdfs:comment>
         <rdfs:label xml:lang="en">REO32 Change in thinking</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO32</skos:notation>
+        <skos:prefLabel xml:lang="en">Change in Thinking</skos:prefLabel>
     </owl:Class>
     
 
@@ -1224,6 +1248,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Produced as an intentional result of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO33 Output</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO33</skos:notation>
+        <skos:prefLabel xml:lang="en">Output</skos:prefLabel>
     </owl:Class>
     
 
@@ -1235,6 +1260,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indication of age at the time of E7 Activity or at the time of report/testimonyof E7 Activity</rdfs:comment>
         <rdfs:label xml:lang="en">REO35 Age (temporal entity)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO35</skos:notation>
+        <skos:prefLabel xml:lang="en">Age</skos:prefLabel>
     </owl:Class>
     
 
@@ -1247,6 +1273,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize the legal status of being (a) a citizen of one (or more) independent states or (b) being a subject of one (or more) imperial systems.</rdfs:comment>
         <rdfs:label xml:lang="en">REO36 Citizenship</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO36</skos:notation>
+        <skos:prefLabel xml:lang="en">Citizenship</skos:prefLabel>
     </owl:Class>
     
 
@@ -1258,6 +1285,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize the identification with one or more than one distinct linguistic community</rdfs:comment>
         <rdfs:label xml:lang="en">REO37 Linguistic communities</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO37</skos:notation>
+        <skos:prefLabel xml:lang="en">Linguistic Communities</skos:prefLabel>
     </owl:Class>
     
 
@@ -1269,6 +1297,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize the identification with one or (more than one) distinct ethnic community.</rdfs:comment>
         <rdfs:label xml:lang="en">RE038 Ethnic communities</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO38</skos:notation>
+        <skos:prefLabel xml:lang="en">Ethnic Communities</skos:prefLabel>
     </owl:Class>
     
 
@@ -1280,6 +1309,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the terms and concepts used to characterize the level of education of the E21 Person at the time of E7 Activity, if known. Disctint from C21 Skill.</rdfs:comment>
         <rdfs:label xml:lang="en">REO39 Educational level</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO39</skos:notation>
+        <skos:prefLabel xml:lang="en">Educational Level</skos:prefLabel>
     </owl:Class>
     
 
@@ -1291,6 +1321,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify the frequency of E7 Activity registered by E21 Person. </rdfs:comment>
         <rdfs:label xml:lang="en">REO4 Frequency</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO4</skos:notation>
+        <skos:prefLabel xml:lang="en">Frequency</skos:prefLabel>
     </owl:Class>
     
 
@@ -1302,6 +1333,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize any information about the content or subject matter of the F2 Expression being read.</rdfs:comment>
         <rdfs:label xml:lang="en">REO40 Subject matter</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO40</skos:notation>
+        <skos:prefLabel xml:lang="en">Subject Matter</skos:prefLabel>
     </owl:Class>
     
 
@@ -1313,6 +1345,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the medium (physical or digital) by which F2 Expression is communicated to E21 Person. The medium (physical or digital) by which the audio recording of a text is communicated to its listener(s).</rdfs:comment>
         <rdfs:label xml:lang="en">REO41 Medium</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO41</skos:notation>
+        <skos:prefLabel xml:lang="en">Medium</skos:prefLabel>
     </owl:Class>
     
 
@@ -1324,6 +1357,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms from thesauri and controlled vocabularies used to characterize and classify the gender of E21 Person at the moment of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO5 Gender</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO5</skos:notation>
+        <skos:prefLabel xml:lang="en">Gender</skos:prefLabel>
     </owl:Class>
     
 
@@ -1336,6 +1370,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms from thesauri and controlled vocabularies used to characterize and classify the literary genre of the F2 Expression.</rdfs:comment>
         <rdfs:label xml:lang="en">REO6 Genre</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO6</skos:notation>
+        <skos:prefLabel xml:lang="en">Genre</skos:prefLabel>
     </owl:Class>
     
 
@@ -1347,6 +1382,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify the level of mental engagement and concentration of E21 Person during E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO7 Intensity</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO7</skos:notation>
+        <skos:prefLabel xml:lang="en">Intensity</skos:prefLabel>
     </owl:Class>
     
 
@@ -1359,6 +1395,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms used to characterize and classify the details of the lighting conditions under which E7 Activity took place.</rdfs:comment>
         <rdfs:label xml:lang="en">REO8 Lighting</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO8</skos:notation>
+        <skos:prefLabel xml:lang="en">Lighting</skos:prefLabel>
     </owl:Class>
     
 
@@ -1371,6 +1408,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises concepts denoted by terms  used to characterize and classify the location within a specific address (or mode of transport) where E7 Activity took place.</rdfs:comment>
         <rdfs:label xml:lang="en">REO9 Location</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO9</skos:notation>
+        <skos:prefLabel xml:lang="en">Location</skos:prefLabel>
     </owl:Class>
     
 
@@ -1387,6 +1425,7 @@ An expression of a work may include expressions of other works within it. For in
 If an instance of F2 Expression is of a specific form, such as text, image, etc., it may be simultaneously instantiated in the specific classes representing these forms in CIDOC CRM. Thereby one can make use of the more specific properties of these classes, such as language (which is applicable to instances of E33 Linguistic Object only).</rdfs:comment>
         <rdfs:label xml:lang="en">F2 Expression</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F2</skos:notation>
+        <skos:prefLabel xml:lang="en">Propositional Object</skos:prefLabel>
     </owl:Class>
     
 
@@ -1399,6 +1438,7 @@ If an instance of F2 Expression is of a specific form, such as text, image, etc.
 			were produced by an industrial process involving an F3 Manifestation Product Type. </rdfs:comment>
         <rdfs:label xml:lang="en">F5 Item</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F5</skos:notation>
+        <skos:prefLabel xml:lang="en">Information Carrier</skos:prefLabel>
     </owl:Class>
     
 
@@ -1413,6 +1453,7 @@ If an instance of F2 Expression is of a specific form, such as text, image, etc.
             hierarchies may be extended with additional properties. </rdfs:comment>
         <rdfs:label xml:lang="en">Type</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E55</skos:notation>
+        <skos:prefLabel xml:lang="en">Type</skos:prefLabel>
     </owl:Class>
 </rdf:RDF>
 

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -1344,7 +1344,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
 
     <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO41">
         <rdfs:subClassOf rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F5"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the medium (physical or digital) by which F2 Expression is communicated to E21 Person. The medium (physical or digital) by which the audio recording of a text is communicated to its listener(s).</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize the medium (physical or digital) by which F2 Expression is communicated to E21 Person. The medium (physical or digital) by which the audio recording of a text is communicated to its listener(s).</rdfs:comment>
         <rdfs:label xml:lang="en">REO41 Medium</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO41</skos:notation>
         <skos:prefLabel xml:lang="en">Medium</skos:prefLabel>

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -574,7 +574,6 @@
     <owl:ObjectProperty rdf:about="http://dataforhistory.org/read-it-ongoing/property/readP4">
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO15"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
-        <rdfs:comment xml:lang="en">xxxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP4 is religion of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP4</skos:notation>
         <skos:prefLabel xml:lang="en">is religion of</skos:prefLabel>
@@ -599,7 +598,6 @@
     <owl:ObjectProperty rdf:about="http://dataforhistory.org/read-it-ongoing/property/readP6">
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO14"/>
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F5"/>
-        <rdfs:comment xml:lang="en">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP6 is provenance of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP6</skos:notation>
         <skos:prefLabel xml:lang="en">is provenance of</skos:prefLabel>
@@ -612,7 +610,6 @@
     <owl:ObjectProperty rdf:about="http://dataforhistory.org/read-it-ongoing/property/readP7">
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO16"/>
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
-        <rdfs:comment xml:lang="en">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP7 is status of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP7</skos:notation>
         <skos:prefLabel xml:lang="en">is status of</skos:prefLabel>
@@ -625,7 +622,6 @@
     <owl:ObjectProperty rdf:about="http://dataforhistory.org/read-it-ongoing/property/readP8">
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO4"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
-        <rdfs:comment xml:lang="en">xxxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP8 is frequency of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP8</skos:notation>
         <skos:prefLabel xml:lang="en">is frequency of</skos:prefLabel>
@@ -638,7 +634,6 @@
     <owl:ObjectProperty rdf:about="http://dataforhistory.org/read-it-ongoing/property/readP9">
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO7"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
-        <rdfs:comment xml:lang="en">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP9 is intensity of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP9</skos:notation>
         <skos:prefLabel xml:lang="en">is intensity of</skos:prefLabel>

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -223,7 +223,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO19"/>
         <rdfs:label xml:lang="en">readP13i has skill</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP13i</skos:notation>
-        <skos:prefLabel xml:lang="en">has skill</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">has reading ability</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -413,7 +413,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP13 is skill of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP13</skos:notation>
-        <skos:prefLabel xml:lang="en">is skill of</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">is reading ability of of</skos:prefLabel>
     </owl:ObjectProperty>
     
 

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -413,7 +413,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP13 is skill of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP13</skos:notation>
-        <skos:prefLabel xml:lang="en">is reading ability of of</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">is reading ability of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -1077,7 +1077,7 @@ The outcome is considered direct effect or consequence resulting from E7 Activit
 
     <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO19">
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xxx</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the terms or concepts used to characterize the level or capacity of performing E7 Activity, based on practical knowledge or know-how, and strategies, as well as trained through practice. Can be about the aptitude to understand immaterial notions, to make inferences, to create mental imagery based on E7 Activity, to act or communicate relevantly about F2 Expression</rdfs:comment>
         <rdfs:label xml:lang="en">REO19 Skill</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO19</skos:notation>
         <skos:prefLabel xml:lang="en">Reading Ability</skos:prefLabel>
@@ -1102,7 +1102,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
 
     <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO20">
         <rdfs:subClassOf rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO23"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xxx</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the terms or concepts used to characterize the general comprehension, awareness or knowledge resulting from E7 Activity or about E7 Activity itself.</rdfs:comment>
         <rdfs:label xml:lang="en">REO20 Understanding</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO20</skos:notation>
         <skos:prefLabel xml:lang="en">Understanding</skos:prefLabel>
@@ -1114,7 +1114,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
 
     <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO21">
         <rdfs:subClassOf rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO23"/>
-        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">xxx</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the terms or concepts used to characterize the affective response (sentiment, appraisal, feeling) associated with E7 Activity</rdfs:comment>
         <rdfs:label xml:lang="en">REO21 Emotions</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO21</skos:notation>
         <skos:prefLabel xml:lang="en">Emotions</skos:prefLabel>

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -54,6 +54,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO35"/>
         <rdfs:label xml:lang="en">readP21i has age</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP21i</skos:notation>
+        <skos:prefLabel xml:lang="en">has age</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -66,6 +67,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO18"/>
         <rdfs:label xml:lang="en">readP15i has aim</rdfs:label>
         <skos:notation xml:lang="en">readP15i</skos:notation>
+        <skos:prefLabel xml:lang="en">has aim</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -78,6 +80,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO36"/>
         <rdfs:label xml:lang="en">readP22i has citizenship</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP22i</skos:notation>
+        <skos:prefLabel xml:lang="en">has citizenship</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -90,6 +93,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO2"/>
         <rdfs:label xml:lang="en">readP11i has disposition</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP11i</skos:notation>
+        <skos:prefLabel xml:lang="en">has disposition</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -102,6 +106,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO39"/>
         <rdfs:label xml:lang="en">readP23i has educational level</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP23i</skos:notation>
+        <skos:prefLabel xml:lang="en">has educational level</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -114,6 +119,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO4"/>
         <rdfs:label xml:lang="en">readP8i has frequency</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP8i</skos:notation>
+        <skos:prefLabel xml:lang="en">has frequency</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -126,6 +132,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO6"/>
         <rdfs:label xml:lang="en">readP5i has genre</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP5i</skos:notation>
+        <skos:prefLabel xml:lang="en">has genre</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -138,6 +145,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO17"/>
         <rdfs:label xml:lang="en">readP12i has habit</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP12i</skos:notation>
+        <skos:prefLabel xml:lang="en">has habit</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -150,6 +158,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO7"/>
         <rdfs:label xml:lang="en">readP9i has intensity</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP9i</skos:notation>
+        <skos:prefLabel xml:lang="en">has intensity</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -162,6 +171,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO41"/>
         <rdfs:label xml:lang="en">readP26i has medium</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP26i</skos:notation>
+        <skos:prefLabel xml:lang="en">has medium</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -174,6 +184,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO10"/>
         <rdfs:label xml:lang="en">readP2i has nationality</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP2i</skos:notation>
+        <skos:prefLabel xml:lang="en">has nationality</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -186,6 +197,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO14"/>
         <rdfs:label xml:lang="en">readP6i has provenance</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP6i</skos:notation>
+        <skos:prefLabel xml:lang="en">has provenance</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -198,6 +210,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO15"/>
         <rdfs:label xml:lang="en">readP4i has religion</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP4i</skos:notation>
+        <skos:prefLabel xml:lang="en">has religion</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -210,6 +223,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO19"/>
         <rdfs:label xml:lang="en">readP13i has skill</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP13i</skos:notation>
+        <skos:prefLabel xml:lang="en">has skill</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -222,6 +236,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO16"/>
         <rdfs:label xml:lang="en">readP7i has status</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP7i</skos:notation>
+        <skos:prefLabel xml:lang="en">has status</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -234,6 +249,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:label xml:lang="en">readP55 is context of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP55</skos:notation>
+        <skos:prefLabel xml:lang="en">is context of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -246,6 +262,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP3i is gender of</rdfs:label>
         <skos:notation>readP3i</skos:notation>
+        <skos:prefLabel xml:lang="en">is gender of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -258,6 +275,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP1i is occupation of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP1i</skos:notation>
+        <skos:prefLabel xml:lang="en">is occupation of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -269,6 +287,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO1"/>
         <rdfs:label xml:lang="en">readP55i has context</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP55i</skos:notation>
+        <skos:prefLabel xml:lang="en">has context</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -281,6 +300,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP25i has member (ethnic communities)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP25i</skos:notation>
+        <skos:prefLabel xml:lang="en">has member (ethnic communities)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -293,6 +313,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP24i has member (linguisitic communities)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP24i</skos:notation>
+        <skos:prefLabel xml:lang="en">has member (linguistic communities)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -310,6 +331,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO30"/>
         <rdfs:label xml:lang="en">readP17i has effect type</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP17i</skos:notation>
+        <skos:prefLabel xml:lang="en">has effect type</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -327,6 +349,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO33"/>
         <rdfs:label xml:lang="en">readP10i has outcome type</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP10i</skos:notation>
+        <skos:prefLabel xml:lang="en">has outcome type</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -338,6 +361,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO11"/>
         <rdfs:label xml:lang="en">readP1 has occupation</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP1</skos:notation>
+        <skos:prefLabel xml:lang="en">has occupation</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -353,6 +377,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO12"/>
         <rdfs:label xml:lang="en">readP10 is outcome type of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP10</skos:notation>
+        <skos:prefLabel xml:lang="en">is outcome type of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -364,6 +389,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP11 is disposition of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP11</skos:notation>
+        <skos:prefLabel xml:lang="en">is disposition of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -375,6 +401,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO2"/>
         <rdfs:label xml:lang="en">readP12 is habit of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP12</skos:notation>
+        <skos:prefLabel xml:lang="en">is habit of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -386,6 +413,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP13 is skill of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP13</skos:notation>
+        <skos:prefLabel xml:lang="en">is skill of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -397,6 +425,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO2"/>
         <rdfs:label xml:lang="en">readP15 is aim of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP15</skos:notation>
+        <skos:prefLabel xml:lang="en">is aim of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -413,6 +442,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO23"/>
         <rdfs:label xml:lang="en">readP17 is effect type of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP17</skos:notation>
+        <skos:prefLabel xml:lang="en">is effect type of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -424,6 +454,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP2 is nationality of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP2</skos:notation>
+        <skos:prefLabel xml:lang="en">is nationality of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -435,6 +466,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP21 is age of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP21</skos:notation>
+        <skos:prefLabel xml:lang="en">is age of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -446,6 +478,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP22 is citizenship of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP22</skos:notation>
+        <skos:prefLabel xml:lang="en">is citizenship of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -457,6 +490,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:label xml:lang="en">readP23 is educational level of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP23</skos:notation>
+        <skos:prefLabel xml:lang="en">is educational level of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -468,6 +502,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO37"/>
         <rdfs:label xml:lang="en">readP24 is member of (linguistic communities)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP24</skos:notation>
+        <skos:prefLabel xml:lang="en">is member of (linguistic communities)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -479,6 +514,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO38"/>
         <rdfs:label xml:lang="en">readP25 is member of (ethnic communities)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP25</skos:notation>
+        <skos:prefLabel xml:lang="en">is member of (ethnic communities)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -490,6 +526,7 @@
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F5"/>
         <rdfs:label xml:lang="en">readP26 is medium of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP26</skos:notation>
+        <skos:prefLabel xml:lang="en">is medium of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -502,6 +539,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:label xml:lang="en">readP27 is triggered by (effects)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP27</skos:notation>
+        <skos:prefLabel xml:lang="en">is triggered by (effects)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -514,6 +552,7 @@
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:label xml:lang="en">readP28 is triggered by (outcomes)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP28</skos:notation>
+        <skos:prefLabel xml:lang="en">is triggered by (outcomes)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -525,6 +564,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO5"/>
         <rdfs:label xml:lang="en">readP3 has gender</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP3</skos:notation>
+        <skos:prefLabel xml:lang="en">has gender</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -537,6 +577,7 @@
         <rdfs:comment xml:lang="en">xxxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP4 is religion of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP4</skos:notation>
+        <skos:prefLabel xml:lang="en">is religion of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -548,6 +589,7 @@
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
         <rdfs:label xml:lang="en">readP5 is genre of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP5</skos:notation>
+        <skos:prefLabel xml:lang="en">is genre of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -560,6 +602,7 @@
         <rdfs:comment xml:lang="en">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP6 is provenance of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP6</skos:notation>
+        <skos:prefLabel xml:lang="en">is provenance of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -572,6 +615,7 @@
         <rdfs:comment xml:lang="en">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP7 is status of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP7</skos:notation>
+        <skos:prefLabel xml:lang="en">is status of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -584,6 +628,7 @@
         <rdfs:comment xml:lang="en">xxxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP8 is frequency of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP8</skos:notation>
+        <skos:prefLabel xml:lang="en">is frequency of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -596,6 +641,7 @@
         <rdfs:comment xml:lang="en">xxx</rdfs:comment>
         <rdfs:label xml:lang="en">readP9 is intensity of</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP9</skos:notation>
+        <skos:prefLabel xml:lang="en">is intensity of</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -607,6 +653,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO23"/>
         <rdfs:label xml:lang="en">readP27i triggers (effects)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP27i</skos:notation>
+        <skos:prefLabel xml:lang="en">triggers (effects)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -618,6 +665,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO12"/>
         <rdfs:label xml:lang="en">readP28i triggers (outcomes)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">readP28i</skos:notation>
+        <skos:prefLabel xml:lang="en">triggers (outcomes)</skos:prefLabel>
     </owl:ObjectProperty>
     
 
@@ -627,6 +675,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P100_was_death_of">
         <rdfs:domain rdf:resource="http://erlangen-crm.org/current/E69_Death"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
+        <skos:prefLabel xml:lang="en">was death of</skos:prefLabel>
     </rdf:Description>
     
 
@@ -636,6 +685,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P100i_died_in">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:range rdf:resource="http://erlangen-crm.org/current/E69_Death"/>
+        <skos:prefLabel xml:lang="en">died in</skos:prefLabel>
     </rdf:Description>
     
 
@@ -645,6 +695,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P102_has_title">
         <rdfs:domain rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
         <rdfs:range rdf:resource="http://erlangen-crm.org/current/E35_Title"/>
+        <skos:prefLabel xml:lang="en">has title</skos:prefLabel>
     </rdf:Description>
     
 
@@ -654,6 +705,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P102i_is_title_of">
         <rdfs:domain rdf:resource="http://erlangen-crm.org/current/E35_Title"/>
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
+        <skos:prefLabel xml:lang="en">is title of</skos:prefLabel>
     </rdf:Description>
     
 
@@ -663,6 +715,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P128_carries">
         <rdfs:domain rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F5"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object"/>
+        <skos:prefLabel xml:lang="en">carries</skos:prefLabel>
     </rdf:Description>
     
 
@@ -672,6 +725,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P128i_is_carried_by">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object"/>
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F5"/>
+        <skos:prefLabel xml:lang="en">is carried by</skos:prefLabel>
     </rdf:Description>
     
 
@@ -681,6 +735,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P129_is_about">
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO40"/>
         <rdfs:range rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
+        <skos:prefLabel xml:lang="en">is about</skos:prefLabel>
     </rdf:Description>
     
 
@@ -690,6 +745,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P129i_is_subject_of">
         <rdfs:domain rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO40"/>
+        <skos:prefLabel xml:lang="en">is subject of</skos:prefLabel>
     </rdf:Description>
     
 
@@ -699,6 +755,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P14_carried_out_by">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
+        <skos:prefLabel xml:lang="en">carried out by</skos:prefLabel>
     </rdf:Description>
     
 
@@ -708,6 +765,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P14i_performed">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <skos:prefLabel xml:lang="en">performed</skos:prefLabel>
     </rdf:Description>
     
 
@@ -717,6 +775,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P15_was_influenced_by">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object"/>
+        <skos:prefLabel xml:lang="en">was influenced by</skos:prefLabel>
     </rdf:Description>
     
 
@@ -726,6 +785,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P15i_influenced">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <skos:prefLabel xml:lang="en">influenced</skos:prefLabel>
     </rdf:Description>
     
 
@@ -735,6 +795,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P4_has_time-span">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span"/>
+        <skos:prefLabel xml:lang="en">has time-span</skos:prefLabel>
     </rdf:Description>
     
 
@@ -744,6 +805,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P4i_is_time-span_of">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <skos:prefLabel xml:lang="en">is time-span of</skos:prefLabel>
     </rdf:Description>
     
 
@@ -756,6 +818,7 @@
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO3"/>
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO8"/>
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO9"/>
+        <skos:prefLabel xml:lang="en">consists of</skos:prefLabel>
     </rdf:Description>
     
 
@@ -768,6 +831,7 @@
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO8"/>
         <rdfs:domain rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO9"/>
         <rdfs:range rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO1"/>
+        <skos:prefLabel xml:lang="en">forms part of</skos:prefLabel>
     </rdf:Description>
     
 
@@ -777,6 +841,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P67_refers_to">
         <rdfs:domain rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object"/>
+        <skos:prefLabel xml:lang="en">refers to</skos:prefLabel>
     </rdf:Description>
     
 
@@ -786,6 +851,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by">
         <rdfs:domain rdf:resource="http://iflastandards.info/ns/fr/frbr/frbroo/F2"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object"/>
+        <skos:prefLabel xml:lang="en">is referred to by</skos:prefLabel>
     </rdf:Description>
     
 
@@ -795,6 +861,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P78_is_identified_by">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E50_Date"/>
+        <skos:prefLabel xml:lang="en">is identified by</skos:prefLabel>
     </rdf:Description>
     
 
@@ -804,6 +871,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P78i_identifies">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E50_Date"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span"/>
+        <skos:prefLabel xml:lang="en">identifies</skos:prefLabel>
     </rdf:Description>
     
 
@@ -813,6 +881,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P7_took_place_at">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E53_Place"/>
+        <skos:prefLabel xml:lang="en">took place at</skos:prefLabel>
     </rdf:Description>
     
 
@@ -822,6 +891,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P7i_witnessed">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E53_Place"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <skos:prefLabel xml:lang="en">witnessed</skos:prefLabel>
     </rdf:Description>
     
 
@@ -831,6 +901,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P87_is_identified_by">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E53_Place"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E48_Place_Name"/>
+        <skos:prefLabel xml:lang="en">is identified by</skos:prefLabel>
     </rdf:Description>
     
 
@@ -840,6 +911,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P87i_identifies">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E48_Place_Name"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E53_Place"/>
+        <skos:prefLabel xml:lang="en">identifies</skos:prefLabel>
     </rdf:Description>
     
 
@@ -849,6 +921,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P98_brought_into_life">
         <rdfs:domain rdf:resource="http://erlangen-crm.org/current/E67_Birth"/>
         <rdfs:range rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
+        <skos:prefLabel xml:lang="en">brought into life</skos:prefLabel>
     </rdf:Description>
     
 
@@ -858,6 +931,7 @@
     <rdf:Description rdf:about="http://www.cidoc-crm.org/cidoc-crm/P98i_was_born">
         <rdfs:domain rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E21_Person"/>
         <rdfs:range rdf:resource="http://erlangen-crm.org/current/E67_Birth"/>
+        <skos:prefLabel xml:lang="en">was born</skos:prefLabel>
     </rdf:Description>
     
 

--- a/REO_2.4.1.owl
+++ b/REO_2.4.1.owl
@@ -988,6 +988,7 @@
 
     <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO12">
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <rdfs:subClassOf rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO42"/>
         <owl:disjointWith rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO23"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the outcome of an action from the E39 Actor or E21 Person perspective.
 The outcome is considered direct effect or consequence resulting from E7 Activity which it follows. Outcome is considered immaterial as it mainly affects the state of mind and the condition of the E39 Actor or E21 Person. Outcome is not only consisting in a change of the state of mind but also in a change of the situation of the E39 Actor or E21 Person. There may be one or many outcomes resulting from E7 Activity.</rdfs:comment>
@@ -1137,6 +1138,7 @@ Premises are considered as the set of personal immaterial dispositions (motivati
 
     <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO23">
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <rdfs:subClassOf rdf:resource="http://dataforhistory.org/read-it-ongoing/class/REO42"/>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class comprises the concepts and terms used to characterize the emotional, intellectual, or psychological effect that the E7 Activity has on the E21 Person at the time of E7 Activity.</rdfs:comment>
         <rdfs:label xml:lang="en">REO23 Effects (internal processes)</rdfs:label>
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO23</skos:notation>
@@ -1545,6 +1547,23 @@ If an instance of F2 Expression is of a specific form, such as text, image, etc.
         <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E56</skos:notation>
         <skos:prefLabel xml:lang="en">Language</skos:prefLabel>
     </owl:Class>
+
+
+
+    <!-- http://dataforhistory.org/read-it-ongoing/class/REO42 -->
+
+    <owl:Class rdf:about="http://dataforhistory.org/read-it-ongoing/class/REO42">
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+        <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">
+            Placeholder class for existing annotations made using the READ-IT skinny ontology.
+            They should be converted to instances of either REO12 or REO23.
+        </rdfs:comment>
+        <rdfs:label xml:lang="en">REO42 Effects/Outcomes</rdfs:label>
+        <skos:notation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REO42</skos:notation>
+        <skos:prefLabel xml:lang="en">Effects/Outcomes</skos:prefLabel>
+    </owl:Class>
+
 </rdf:RDF>
 
 


### PR DESCRIPTION
This PR does a few things:

1. Provide `skos:prefLabel` to every class and property, for use in the interface. These are take from the mapping document supplied by @fvignale 
2. Add some triples information for `E21`, `E7`, `E67`, `E69`, `E53`, `E50`, `E35`, `E39`, and `E56`. This is done so `skos:prefLabel` can be added. The definitions follow the conventions used by the other classes, but lack `rdfs:comment`. @fvignale please feel free to add them if you deem this necessary, I do not want to interfere with your method of describing the ontology.
3. Introduce `REO42 Effects/Outcomes`. As discussed, this is a deprecated superclass for `REO12` and `REO23`.

@jgonggrijp Please let me know if I missed any steps for preparing the ontology for migration. 